### PR TITLE
Adjust tag name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       name: Check out code into the Go module directory
 
     - name: Build
-      run: make dist VERSION=${{ github.ref }}
+      run: make dist VERSION=${{ github.event.release.tag_name }}
 
     - name: Create Release
       id: create_release
@@ -31,7 +31,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        release_name: Release ${{ github.event.release.tag_name }}
         draft: true
         prerelease: true
 
@@ -42,7 +42,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./bin/linux.tgz
-        asset_name: linux-${{ github.ref }}.tgz
+        asset_name: linux-${{ github.event.release.tag_name }}.tgz
         asset_content_type: application/tar+gzip
 
     - name: Upload macos
@@ -52,7 +52,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./bin/darwin.tgz
-        asset_name: darwin-${{ github.ref }}.tgz
+        asset_name: darwin-${{ github.event.release.tag_name }}.tgz
         asset_content_type: application/tar+gzip
 
     - name: Upload windows
@@ -62,5 +62,5 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./bin/windows.tgz
-        asset_name: windows-${{ github.ref }}.tgz
+        asset_name: windows-${{ github.event.release.tag_name }}.tgz
         asset_content_type: application/tar+gzip


### PR DESCRIPTION
It turns out github.ref contains `ref/tags/` as a prefix which causes
some problems.  github.event.release.tag_name should be just the tag