### PR TITLE
Use a better annotation key

### DIFF
--- a/pkg/driver/kubernetes/manifest/manifest.go
+++ b/pkg/driver/kubernetes/manifest/manifest.go
@@ -27,7 +27,7 @@ type DeploymentOpt struct {
 
 const (
 	containerName = "buildkitd"
-	AnnotationKey = "buildkit.org/builder"
+	AnnotationKey = "buildkit.mobyproject.org/builder"
 )
 
 func labels(opt *DeploymentOpt) map[string]string {


### PR DESCRIPTION
buildkit.org isn't a valid domain, so lets use the same
scheme BuildKit uses for labels