### PR TITLE
Fix dist target to use windows exe suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ print-%:
 build-ci: $(CI_BUILD_TARGETS)
 
 .PHONY: dist
-dist: $(CI_ARCHIVES)
+dist: $(CI_BUILD_TARGETS) $(CI_ARCHIVES)
 
-$(BIN_DIR)/%.tgz: $(BIN_DIR)/%/kubectl-buildkit $(BIN_DIR)/%/kubectl-build
-	cd $(BIN_DIR)/$* && tar -czvf ../$*.tgz kubectl-buildkit kubectl-build
+$(BIN_DIR)/%.tgz: $(BIN_DIR)/%/*
+	cd $(BIN_DIR)/$* && tar -czvf ../$*.tgz kubectl-*
 
 .PHONY: test
 test:


### PR DESCRIPTION
Continuation of #48 

I forgot to test the `dist` target when I fixed `make build-ci` and overlooked this also needed to be refactored a little

```
% make clean
rm -rf ./bin cover*.out cover.html
% make dist
GOOS=linux go build -ldflags "-X github.com/vmware-tanzu/buildkit-cli-for-kubectl/version.Version=v0.1.1-0-gc3b0e96-dirty" -mod=vendor -o bin/linux/kubectl-buildkit ./cmd/kubectl-buildkit
GOOS=linux go build -ldflags "-X github.com/vmware-tanzu/buildkit-cli-for-kubectl/version.Version=v0.1.1-0-gc3b0e96-dirty" -mod=vendor -o bin/linux/kubectl-build  ./cmd/kubectl-build
GOOS=darwin go build -ldflags "-X github.com/vmware-tanzu/buildkit-cli-for-kubectl/version.Version=v0.1.1-0-gc3b0e96-dirty" -mod=vendor -o bin/darwin/kubectl-buildkit ./cmd/kubectl-buildkit
GOOS=darwin go build -ldflags "-X github.com/vmware-tanzu/buildkit-cli-for-kubectl/version.Version=v0.1.1-0-gc3b0e96-dirty" -mod=vendor -o bin/darwin/kubectl-build  ./cmd/kubectl-build
GOOS=windows go build -ldflags "-X github.com/vmware-tanzu/buildkit-cli-for-kubectl/version.Version=v0.1.1-0-gc3b0e96-dirty" -mod=vendor -o bin/windows/kubectl-buildkit.exe ./cmd/kubectl-buildkit
GOOS=windows go build -ldflags "-X github.com/vmware-tanzu/buildkit-cli-for-kubectl/version.Version=v0.1.1-0-gc3b0e96-dirty" -mod=vendor -o bin/windows/kubectl-build.exe  ./cmd/kubectl-build
cd ./bin/linux && tar -czvf ../linux.tgz kubectl-*
a kubectl-build
a kubectl-buildkit
cd ./bin/darwin && tar -czvf ../darwin.tgz kubectl-*
a kubectl-build
a kubectl-buildkit
cd ./bin/windows && tar -czvf ../windows.tgz kubectl-*
a kubectl-build.exe
a kubectl-buildkit.exe
% tar tzf bin/windows.tgz 
kubectl-build.exe
kubectl-buildkit.exe
```