### PR TITLE
Wire up CI for post-merge as well

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,9 @@
-name: pull-request
+name: pre-and-post-merge
 
 on:
   pull_request:
+    branches: [ main ]
+  push:
     branches: [ main ]
 
 env:
@@ -22,7 +24,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: cover-unit.out 
+        file: cover-unit.out
         flags: unit-tests
         name: codecov-unit-test
 
@@ -36,24 +38,13 @@ jobs:
     - uses: actions/checkout@v2
       name: Check out code into the Go module directory
     - name: Setup kind cluster
-      run: |
-        set -x
-        # kind configuration.
-        cat > kind.yaml <<EOF
-        apiVersion: kind.x-k8s.io/v1alpha4
-        kind: Cluster
-        nodes:
-        - role: control-plane
-        - role: worker
-        EOF
-        # Create a cluster!
-        kind create cluster --config kind.yaml
+      run: kind create cluster --config ./integration/kind-ci.yaml
     - name: Run integration tests
       run: make integration EXTRA_GO_TEST_FLAGS=-v
     - name: Gather integration coverage results
       uses: codecov/codecov-action@v1
       with:
-        file: cover-int.out 
+        file: cover-int.out
         flags: integration-tests
         name: codecov-integration-test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 bin/*
 cover*.out
-cover.html
+cover*.html

--- a/integration/kind-ci.yaml
+++ b/integration/kind-ci.yaml
@@ -1,0 +1,8 @@
+# kind configuration for CI
+# Usage:
+#   kind create cluster --config ./integration/kind-ci.yaml
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+- role: worker


### PR DESCRIPTION
This should get the code coverage published for post-merge commits so
codecov can generate proper diff's for PRs.