### PR TITLE
Harden default creation for parallel invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,3 @@ cover.html: cover-int.out cover-unit.out
 .PHONY: lint
 lint:
 	golangci-lint run
-

--- a/integration/common/kubeclient.go
+++ b/integration/common/kubeclient.go
@@ -62,7 +62,9 @@ func RunSimpleBuildImageAsPod(ctx context.Context, name, imageName, namespace st
 
 	defer func() {
 		err := podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-		logrus.Warnf("failed to clean up pod %s: %s", pod.Name, err)
+		if err != nil {
+			logrus.Warnf("failed to clean up pod %s: %s", pod.Name, err)
+		}
 	}()
 
 	logrus.Infof("waiting for pod to start...")

--- a/integration/suites/parallel_default_test.go
+++ b/integration/suites/parallel_default_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package suites
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/integration/common"
+
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const ParallelDefaultBuildCount = 3
+
+type parallelDefaultSuite struct {
+	suite.Suite
+	Name        string
+	CreateFlags []string
+
+	ClientSet *kubernetes.Clientset
+	Namespace string
+
+	configMapClient v1.ConfigMapInterface
+}
+
+func (s *parallelDefaultSuite) SetupSuite() {
+	var err error
+	s.ClientSet, s.Namespace, err = common.GetKubeClientset()
+	require.NoError(s.T(), err, "%s: kube client failed", s.Name)
+	s.configMapClient = s.ClientSet.CoreV1().ConfigMaps(s.Namespace)
+}
+
+func (s *parallelDefaultSuite) TestParallelDefaultBuilds() {
+	logrus.Infof("%s: Parallel %d Build", s.Name, ParallelDefaultBuildCount)
+
+	dirs := make([]string, ParallelDefaultBuildCount)
+	errors := make([]error, ParallelDefaultBuildCount)
+
+	// Create the contexts before threading
+	for i := 0; i < ParallelDefaultBuildCount; i++ {
+		dir, cleanup, err := common.NewSimpleBuildContext()
+		dirs[i] = dir
+		require.NoError(s.T(), err, "Failed to set up temporary build context")
+		defer cleanup()
+	}
+	wg := &sync.WaitGroup{}
+	wg.Add(ParallelDefaultBuildCount)
+
+	for i := 0; i < ParallelDefaultBuildCount; i++ {
+		go func(i int) {
+			defer wg.Done()
+			imageName := fmt.Sprintf("dummy.acme.com/pbuild:%d", i)
+			args := []string{
+				"--progress=plain",
+				"--tag", imageName,
+				dirs[i],
+			}
+			err := common.RunBuild(args)
+			if err != nil {
+				errors[i] = err
+				return
+			}
+			errors[i] = common.RunSimpleBuildImageAsPod(
+				context.Background(),
+				fmt.Sprintf("%s-testbuiltimage-%d", s.Name, i),
+				imageName,
+				s.Namespace,
+				s.ClientSet,
+			)
+
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < ParallelDefaultBuildCount; i++ {
+		require.NoError(s.T(), errors[i], "build/run %d failed", i)
+	}
+}
+
+func TestParallelDefaultBuildSuite(t *testing.T) {
+	common.Skipper(t)
+	// We don't parallelize with other tests, since we use the default builder name
+	suite.Run(t, &parallelDefaultSuite{
+		Name: "buildkit",
+	})
+}


### PR DESCRIPTION
If multiple build commands are run in parallel without a builder already
existing, there are race conditions where those default creations can
get confused and cause builds to fail
This adds a new test case to verify parallel builds work, and hardens
the bootstrapping code to detect "already exists" errors and retry

Closes #55 