### PR TITLE
Add support for custom config mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ You can then build using the registry cache with the command:
 kubectl build -t myimage --cache-to=type=registry,ref=registry:5000/cache --cache-from=type=registry,ref=registry:5000/cache .
 ```
 
+## Custom Certs for Registries
+
+If you happen to run a container image registry with non-standard certs (self signed, or signed by a private CA)
+you can configure buildkitd to trust those certificates.
+
+First load your certs into a ConfigMap:
+```sh
+kubectl create configmap custom-root-certs --from-file=root_ca1.pem --from-file=root_ca2.pem
+```
+
+Then create a `buildkitd.toml` file for your registries where the certs above will be mounted into `/etc/config`
+```
+debug = false
+[worker.containerd]
+  namespace = "k8s.io"
+[registry."myregistry1.acme.local"]
+    ca=["/etc/config/root_ca1.pem"]
+[registry."myregistry2.acme.local:5001"]
+    ca=["/etc/config/root_ca2.pem"]
+```
+
+You can then create a customized builder with
+```
+kubectl buildkit create --custom-config=custom-root-certs --config ./buildkitd.toml
+```
+
 ## Contributing
 
 Check out our [contributing](./CONTRIBUTING.md) for guidance on how to help contribute to the project.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/grpc v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -570,6 +571,7 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/integration/suites/localregistry_test.go
+++ b/integration/suites/localregistry_test.go
@@ -1,0 +1,304 @@
+// Copyright (C) 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package suites
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/integration/common"
+
+	"golang.org/x/crypto/bcrypt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/cert"
+)
+
+const (
+	RegistryImageName = "docker.io/registry:2.7"
+)
+
+type localRegistrySuite struct {
+	suite.Suite
+	Name        string
+	CreateFlags []string
+
+	ClientSet *kubernetes.Clientset
+	Namespace string
+
+	configMapClient v1.ConfigMapInterface
+	secretClient    v1.SecretInterface
+	podClient       v1.PodInterface
+	serviceClient   v1.ServiceInterface
+	configMapName   string
+	registryName    string
+	registryFQDN    string
+
+	skipTeardown bool
+}
+
+func (s *localRegistrySuite) SetupSuite() {
+	// s.skipTeardown = true
+	var err error
+	ctx := context.Background()
+	s.ClientSet, s.Namespace, err = common.GetKubeClientset()
+	require.NoError(s.T(), err, "%s: kube client failed", s.Name)
+	s.configMapClient = s.ClientSet.CoreV1().ConfigMaps(s.Namespace)
+	s.secretClient = s.ClientSet.CoreV1().Secrets(s.Namespace)
+	s.podClient = s.ClientSet.CoreV1().Pods(s.Namespace)
+	s.serviceClient = s.ClientSet.CoreV1().Services(s.Namespace)
+
+	s.configMapName = s.Name + "-certs"
+	s.registryName = s.Name + "-registry"
+	s.registryFQDN = s.registryName + "." + s.Namespace + ".svc.cluster.local"
+	username := "jdoe"
+	password := "supersecret"
+
+	// Generate TLS certificates
+	logrus.Infof("%s: Generating self-signed cert for the registry", s.Name)
+	crt, key, err := cert.GenerateSelfSignedCertKey("registry", nil, []string{s.registryFQDN})
+	require.NoError(s.T(), err, "%s: self signed cert gen failed", s.Name)
+
+	// Create the htpassword compatible payload for the registry to use
+	hashedPass, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	require.NoError(s.T(), err, "%s: htpasswd generation failed", s.Name)
+
+	htpass := fmt.Sprintf("%s:%s",
+		username,
+		hashedPass,
+	)
+
+	// Stuff the certs into a configmap (yes, this is technically wrong, a private key
+	// should never go in a ConfigMap but rather a Secret)
+	cfgMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: s.Namespace,
+			Name:      s.configMapName,
+		},
+		BinaryData: map[string][]byte{
+			"cert.pem": crt,
+			"key.pem":  key,
+			"htpasswd": []byte(htpass),
+		},
+	}
+	_, err = s.configMapClient.Create(context.Background(), cfgMap, metav1.CreateOptions{})
+	require.NoError(s.T(), err, "%s: create configmap failed", s.Name)
+
+	// Create some registry credentials
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: s.Namespace,
+			Name:      s.Name, // Use the builder name so that we auto-mount the secret
+		},
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(
+				fmt.Sprintf(
+					`{"auths":{"%s":{"username":"%s","password":"%s"}}}`,
+					s.registryFQDN,
+					username,
+					password,
+				),
+			),
+		},
+	}
+	_, err = s.secretClient.Create(context.Background(), secret, metav1.CreateOptions{})
+	require.NoError(s.T(), err, "%s: create registry secret failed", s.Name)
+
+	// Start up the local registry
+	logrus.Infof("%s: Running local registry pod %s with cert", s.Name, s.registryName)
+	_, err = s.podClient.Create(ctx,
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: s.registryName,
+				Labels: map[string]string{
+					"app": s.registryName,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "registry",
+						Image:           RegistryImageName,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Env: []corev1.EnvVar{
+							{
+								Name:  "REGISTRY_HTTP_TLS_CERTIFICATE",
+								Value: "/certs/cert.pem",
+							},
+							{
+								Name:  "REGISTRY_HTTP_TLS_KEY",
+								Value: "/certs/key.pem",
+							},
+							{
+								Name:  "REGISTRY_HTTP_ADDR",
+								Value: "0.0.0.0:443",
+							},
+							{
+								Name:  "REGISTRY_AUTH_HTPASSWD_PATH",
+								Value: "/certs/htpasswd",
+							},
+							{
+								Name:  "REGISTRY_AUTH_HTPASSWD_REALM",
+								Value: "Registry Realm",
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "registry-tls",
+								HostPort:      443,
+								ContainerPort: 443,
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "certs",
+								MountPath: "/certs/",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "certs",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: s.configMapName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(s.T(), err, "%s: create registry pod failed", s.Name)
+
+	logrus.Infof("%s: Creating ClusterIP Service for registry %s", s.Name, s.registryName)
+	_, err = s.serviceClient.Create(ctx,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: s.registryName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "registry-tls",
+						Port: 443,
+					},
+				},
+				Selector: map[string]string{
+					"app": s.registryName,
+				},
+				Type: corev1.ServiceTypeClusterIP,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(s.T(), err, "%s: create registry service failed", s.Name)
+
+	// Now create the builder with the certs mapped and a config that trusts this local registry
+	logrus.Infof("%s: Creating custom builder with registry cert and config %s", s.Name, s.registryName)
+	dir, cleanup, err := common.NewBuildContext(map[string]string{
+		"buildkitd.toml": fmt.Sprintf(`debug = false
+[worker.containerd]
+	namespace = "k8s.io"
+[registry."%s"]
+	ca=["/etc/config/cert.pem"]
+`, s.registryFQDN)})
+	require.NoError(s.T(), err, "%s: config file create failed", s.Name)
+
+	defer cleanup()
+
+	args := append(
+		[]string{
+			"--config", filepath.Join(dir, "buildkitd.toml"),
+			"--custom-config", s.configMapName,
+			s.Name,
+		},
+		s.CreateFlags...,
+	)
+	err = common.RunBuildkit("create", args)
+	require.NoError(s.T(), err, "%s: builder creation failed", s.Name)
+}
+
+func (s *localRegistrySuite) TearDownSuite() {
+	if !s.skipTeardown {
+
+		ctx := context.Background()
+
+		// Clean everything up...
+		err := s.podClient.Delete(ctx, s.registryName, metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Warnf("failed to clean up pod %s: %s", s.registryName, err)
+		}
+		err = s.serviceClient.Delete(ctx, s.registryName, metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Warnf("failed to clean up service %s: %s", s.registryName, err)
+		}
+		err = s.configMapClient.Delete(ctx, s.configMapName, metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Warnf("failed to clean up configMap %s: %s", s.configMapName, err)
+		}
+		err = s.secretClient.Delete(ctx, s.Name, metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Warnf("failed to clean up registry secret %s: %s", s.configMapName, err)
+		}
+
+		logrus.Infof("%s: Removing builder", s.Name)
+		err = common.RunBuildkit("rm", []string{
+			s.Name,
+		})
+		if err != nil {
+			logrus.Warnf("failed to clean up builder %s", err)
+		}
+
+	}
+}
+
+func (s *localRegistrySuite) TestBuildWithPush() {
+	logrus.Infof("%s: Registry Push Build", s.Name)
+
+	dir, cleanup, err := common.NewSimpleBuildContext()
+	defer cleanup()
+	require.NoError(s.T(), err, "Failed to set up temporary build context")
+	imageName := s.registryFQDN + "/" + s.Name + "replaceme:latest"
+	args := []string{"--progress=plain",
+		"--builder", s.Name,
+		"--push",
+		"--tag", imageName,
+		dir,
+	}
+	err = common.RunBuild(args)
+	require.NoError(s.T(), err, "build failed")
+	// Note, we can't run the image we just built since it was pushed to the local registry, which isn't ~directly visible to the runtime
+}
+
+// TODO add testcase for caching scenarios here
+
+func TestLocalRegistrySuite(t *testing.T) {
+	common.Skipper(t)
+	// TODO this testcase should be safe to run parallel, but I'm seeing failures in CI that look
+	// like containerd runtime concurrency problems.  They don't seem related to this particular change though
+	//t.Parallel()
+	suite.Run(t, &localRegistrySuite{
+		Name: "regtest",
+	})
+}

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -41,6 +41,7 @@ type createOptions struct {
 	flags               string
 	configFile          string
 	progress            string
+	customConfig        string
 }
 
 func runCreate(streams genericclioptions.IOStreams, in createOptions, rootOpts *rootOptions) error {
@@ -76,6 +77,7 @@ func runCreate(streams genericclioptions.IOStreams, in createOptions, rootOpts *
 		"containerd-sock":      in.containerdSock,
 		"docker-sock":          in.dockerSock,
 		"runtime":              in.runtime,
+		"custom-config":        in.customConfig,
 	}
 
 	d, err := driver.GetDriver(ctx, in.name, driverFactory, rootOpts.KubeClientConfig, flags, in.configFile, driverOpts, "" /*contextPathHash*/)
@@ -137,6 +139,7 @@ Driver Specific Usage:
 	flags.BoolVar(&options.rootless, "rootless", false, "Run in rootless mode")
 	flags.StringVar(&options.loadbalance, "loadbalance", "random", "Load balancing strategy [random, sticky]")
 	flags.StringVar(&options.worker, "worker", "auto", "Worker backend [auto, runc, containerd]")
+	flags.StringVar(&options.customConfig, "custom-config", "", "Name of a ConfigMap containing custom files (e.g., certs), mounted in /etc/config/ - use 'kubectl create configmap ... --from-file=...'")
 
 	return cmd
 }

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -51,7 +51,6 @@ const (
 	// TODO - consider adding other default values here to aid users in fine-tuning by editing the configmap post deployment
 	DefaultConfigFileTemplate = `# Default buildkitd configuration.  Use --config <path/to/file> to override during create
 debug = false
-root = "/var/lib/buildkit/{{ .Name }}"
 [worker.containerd]
   namespace = "{{ .ContainerdNamespace }}"
 `

--- a/pkg/driver/kubernetes/factory.go
+++ b/pkg/driver/kubernetes/factory.go
@@ -176,6 +176,8 @@ func (d *Driver) initDriverFromConfig() error {
 				return errors.Errorf("invalid runtime %q", v)
 			}
 			deploymentOpt.ContainerRuntime = v
+		case "custom-config":
+			deploymentOpt.CustomConfig = v
 		default:
 			return errors.Errorf("invalid driver option %s for driver %s", k, DriverName)
 		}

--- a/vendor/golang.org/x/crypto/bcrypt/base64.go
+++ b/vendor/golang.org/x/crypto/bcrypt/base64.go
@@ -1,0 +1,35 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bcrypt
+
+import "encoding/base64"
+
+const alphabet = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+var bcEncoding = base64.NewEncoding(alphabet)
+
+func base64Encode(src []byte) []byte {
+	n := bcEncoding.EncodedLen(len(src))
+	dst := make([]byte, n)
+	bcEncoding.Encode(dst, src)
+	for dst[n-1] == '=' {
+		n--
+	}
+	return dst[:n]
+}
+
+func base64Decode(src []byte) ([]byte, error) {
+	numOfEquals := 4 - (len(src) % 4)
+	for i := 0; i < numOfEquals; i++ {
+		src = append(src, '=')
+	}
+
+	dst := make([]byte, bcEncoding.DecodedLen(len(src)))
+	n, err := bcEncoding.Decode(dst, src)
+	if err != nil {
+		return nil, err
+	}
+	return dst[:n], nil
+}

--- a/vendor/golang.org/x/crypto/bcrypt/bcrypt.go
+++ b/vendor/golang.org/x/crypto/bcrypt/bcrypt.go
@@ -1,0 +1,295 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package bcrypt implements Provos and Mazières's bcrypt adaptive hashing
+// algorithm. See http://www.usenix.org/event/usenix99/provos/provos.pdf
+package bcrypt // import "golang.org/x/crypto/bcrypt"
+
+// The code is a port of Provos and Mazières's C implementation.
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"golang.org/x/crypto/blowfish"
+)
+
+const (
+	MinCost     int = 4  // the minimum allowable cost as passed in to GenerateFromPassword
+	MaxCost     int = 31 // the maximum allowable cost as passed in to GenerateFromPassword
+	DefaultCost int = 10 // the cost that will actually be set if a cost below MinCost is passed into GenerateFromPassword
+)
+
+// The error returned from CompareHashAndPassword when a password and hash do
+// not match.
+var ErrMismatchedHashAndPassword = errors.New("crypto/bcrypt: hashedPassword is not the hash of the given password")
+
+// The error returned from CompareHashAndPassword when a hash is too short to
+// be a bcrypt hash.
+var ErrHashTooShort = errors.New("crypto/bcrypt: hashedSecret too short to be a bcrypted password")
+
+// The error returned from CompareHashAndPassword when a hash was created with
+// a bcrypt algorithm newer than this implementation.
+type HashVersionTooNewError byte
+
+func (hv HashVersionTooNewError) Error() string {
+	return fmt.Sprintf("crypto/bcrypt: bcrypt algorithm version '%c' requested is newer than current version '%c'", byte(hv), majorVersion)
+}
+
+// The error returned from CompareHashAndPassword when a hash starts with something other than '$'
+type InvalidHashPrefixError byte
+
+func (ih InvalidHashPrefixError) Error() string {
+	return fmt.Sprintf("crypto/bcrypt: bcrypt hashes must start with '$', but hashedSecret started with '%c'", byte(ih))
+}
+
+type InvalidCostError int
+
+func (ic InvalidCostError) Error() string {
+	return fmt.Sprintf("crypto/bcrypt: cost %d is outside allowed range (%d,%d)", int(ic), int(MinCost), int(MaxCost))
+}
+
+const (
+	majorVersion       = '2'
+	minorVersion       = 'a'
+	maxSaltSize        = 16
+	maxCryptedHashSize = 23
+	encodedSaltSize    = 22
+	encodedHashSize    = 31
+	minHashSize        = 59
+)
+
+// magicCipherData is an IV for the 64 Blowfish encryption calls in
+// bcrypt(). It's the string "OrpheanBeholderScryDoubt" in big-endian bytes.
+var magicCipherData = []byte{
+	0x4f, 0x72, 0x70, 0x68,
+	0x65, 0x61, 0x6e, 0x42,
+	0x65, 0x68, 0x6f, 0x6c,
+	0x64, 0x65, 0x72, 0x53,
+	0x63, 0x72, 0x79, 0x44,
+	0x6f, 0x75, 0x62, 0x74,
+}
+
+type hashed struct {
+	hash  []byte
+	salt  []byte
+	cost  int // allowed range is MinCost to MaxCost
+	major byte
+	minor byte
+}
+
+// GenerateFromPassword returns the bcrypt hash of the password at the given
+// cost. If the cost given is less than MinCost, the cost will be set to
+// DefaultCost, instead. Use CompareHashAndPassword, as defined in this package,
+// to compare the returned hashed password with its cleartext version.
+func GenerateFromPassword(password []byte, cost int) ([]byte, error) {
+	p, err := newFromPassword(password, cost)
+	if err != nil {
+		return nil, err
+	}
+	return p.Hash(), nil
+}
+
+// CompareHashAndPassword compares a bcrypt hashed password with its possible
+// plaintext equivalent. Returns nil on success, or an error on failure.
+func CompareHashAndPassword(hashedPassword, password []byte) error {
+	p, err := newFromHash(hashedPassword)
+	if err != nil {
+		return err
+	}
+
+	otherHash, err := bcrypt(password, p.cost, p.salt)
+	if err != nil {
+		return err
+	}
+
+	otherP := &hashed{otherHash, p.salt, p.cost, p.major, p.minor}
+	if subtle.ConstantTimeCompare(p.Hash(), otherP.Hash()) == 1 {
+		return nil
+	}
+
+	return ErrMismatchedHashAndPassword
+}
+
+// Cost returns the hashing cost used to create the given hashed
+// password. When, in the future, the hashing cost of a password system needs
+// to be increased in order to adjust for greater computational power, this
+// function allows one to establish which passwords need to be updated.
+func Cost(hashedPassword []byte) (int, error) {
+	p, err := newFromHash(hashedPassword)
+	if err != nil {
+		return 0, err
+	}
+	return p.cost, nil
+}
+
+func newFromPassword(password []byte, cost int) (*hashed, error) {
+	if cost < MinCost {
+		cost = DefaultCost
+	}
+	p := new(hashed)
+	p.major = majorVersion
+	p.minor = minorVersion
+
+	err := checkCost(cost)
+	if err != nil {
+		return nil, err
+	}
+	p.cost = cost
+
+	unencodedSalt := make([]byte, maxSaltSize)
+	_, err = io.ReadFull(rand.Reader, unencodedSalt)
+	if err != nil {
+		return nil, err
+	}
+
+	p.salt = base64Encode(unencodedSalt)
+	hash, err := bcrypt(password, p.cost, p.salt)
+	if err != nil {
+		return nil, err
+	}
+	p.hash = hash
+	return p, err
+}
+
+func newFromHash(hashedSecret []byte) (*hashed, error) {
+	if len(hashedSecret) < minHashSize {
+		return nil, ErrHashTooShort
+	}
+	p := new(hashed)
+	n, err := p.decodeVersion(hashedSecret)
+	if err != nil {
+		return nil, err
+	}
+	hashedSecret = hashedSecret[n:]
+	n, err = p.decodeCost(hashedSecret)
+	if err != nil {
+		return nil, err
+	}
+	hashedSecret = hashedSecret[n:]
+
+	// The "+2" is here because we'll have to append at most 2 '=' to the salt
+	// when base64 decoding it in expensiveBlowfishSetup().
+	p.salt = make([]byte, encodedSaltSize, encodedSaltSize+2)
+	copy(p.salt, hashedSecret[:encodedSaltSize])
+
+	hashedSecret = hashedSecret[encodedSaltSize:]
+	p.hash = make([]byte, len(hashedSecret))
+	copy(p.hash, hashedSecret)
+
+	return p, nil
+}
+
+func bcrypt(password []byte, cost int, salt []byte) ([]byte, error) {
+	cipherData := make([]byte, len(magicCipherData))
+	copy(cipherData, magicCipherData)
+
+	c, err := expensiveBlowfishSetup(password, uint32(cost), salt)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < 24; i += 8 {
+		for j := 0; j < 64; j++ {
+			c.Encrypt(cipherData[i:i+8], cipherData[i:i+8])
+		}
+	}
+
+	// Bug compatibility with C bcrypt implementations. We only encode 23 of
+	// the 24 bytes encrypted.
+	hsh := base64Encode(cipherData[:maxCryptedHashSize])
+	return hsh, nil
+}
+
+func expensiveBlowfishSetup(key []byte, cost uint32, salt []byte) (*blowfish.Cipher, error) {
+	csalt, err := base64Decode(salt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Bug compatibility with C bcrypt implementations. They use the trailing
+	// NULL in the key string during expansion.
+	// We copy the key to prevent changing the underlying array.
+	ckey := append(key[:len(key):len(key)], 0)
+
+	c, err := blowfish.NewSaltedCipher(ckey, csalt)
+	if err != nil {
+		return nil, err
+	}
+
+	var i, rounds uint64
+	rounds = 1 << cost
+	for i = 0; i < rounds; i++ {
+		blowfish.ExpandKey(ckey, c)
+		blowfish.ExpandKey(csalt, c)
+	}
+
+	return c, nil
+}
+
+func (p *hashed) Hash() []byte {
+	arr := make([]byte, 60)
+	arr[0] = '$'
+	arr[1] = p.major
+	n := 2
+	if p.minor != 0 {
+		arr[2] = p.minor
+		n = 3
+	}
+	arr[n] = '$'
+	n++
+	copy(arr[n:], []byte(fmt.Sprintf("%02d", p.cost)))
+	n += 2
+	arr[n] = '$'
+	n++
+	copy(arr[n:], p.salt)
+	n += encodedSaltSize
+	copy(arr[n:], p.hash)
+	n += encodedHashSize
+	return arr[:n]
+}
+
+func (p *hashed) decodeVersion(sbytes []byte) (int, error) {
+	if sbytes[0] != '$' {
+		return -1, InvalidHashPrefixError(sbytes[0])
+	}
+	if sbytes[1] > majorVersion {
+		return -1, HashVersionTooNewError(sbytes[1])
+	}
+	p.major = sbytes[1]
+	n := 3
+	if sbytes[2] != '$' {
+		p.minor = sbytes[2]
+		n++
+	}
+	return n, nil
+}
+
+// sbytes should begin where decodeVersion left off.
+func (p *hashed) decodeCost(sbytes []byte) (int, error) {
+	cost, err := strconv.Atoi(string(sbytes[0:2]))
+	if err != nil {
+		return -1, err
+	}
+	err = checkCost(cost)
+	if err != nil {
+		return -1, err
+	}
+	p.cost = cost
+	return 3, nil
+}
+
+func (p *hashed) String() string {
+	return fmt.Sprintf("&{hash: %#v, salt: %#v, cost: %d, major: %c, minor: %c}", string(p.hash), p.salt, p.cost, p.major, p.minor)
+}
+
+func checkCost(cost int) error {
+	if cost < MinCost || cost > MaxCost {
+		return InvalidCostError(cost)
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,6 +302,8 @@ go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
 # golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
+## explicit
+golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/curve25519


### PR DESCRIPTION
This adds support to mount a custom ConfigMap containing files
into /etc/config which can then be used for tuning the buildkitd
configuration.  For example, if your registry uses self-signed or
non-standard certs, you can pass those in and configure buildkitd
to trust them.