### PR TITLE
WIP Implement Native multiarch support

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -238,10 +238,16 @@ func buildTargets(ctx context.Context, kubeClientConfig clientcmd.ClientConfig, 
 	if err != nil {
 		return err
 	}
+	driverInfo, err := d.Info(ctx)
+	if err != nil {
+		return err
+	}
 	dis := []build.DriverInfo{
 		{
-			Name:   driverName,
-			Driver: d,
+			Name:     driverName,
+			Driver:   d,
+			Platform: UniquePlatforms(driverInfo.DynamicNodes),
+			Nodes:    driverInfo.DynamicNodes,
 		},
 	}
 

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -5,7 +5,10 @@ package commands
 import (
 	"fmt"
 
+	"github.com/containerd/containerd/platforms"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/store"
 
 	"github.com/pkg/errors"
 )
@@ -27,4 +30,20 @@ func ExactArgs(count int) func(cmd *cobra.Command, args []string) error {
 			cmd.Short,
 		)
 	}
+}
+
+func UniquePlatforms(nodes []store.Node) []specs.Platform {
+	platformMap := map[string]specs.Platform{}
+	for _, node := range nodes {
+		for _, platform := range node.Platforms {
+			platformMap[platforms.Format(platform)] = platform
+		}
+	}
+	ret := make([]specs.Platform, len(platformMap))
+	i := 0
+	for _, platform := range platformMap {
+		ret[i] = platform
+		i++
+	}
+	return ret
 }


### PR DESCRIPTION
Doesn't work yet...

On my mixed architecture cluster with x86 and Raspberry PI's using the docker runtime, it fails with:
```
...
 => => resolve docker.io/library/busybox:latest@sha256:e1488cb900233d035575f0a7787448cb1fa93bed0ccc0d4efc1963d7d72a8f17                                                             0.0s
 => ERROR exporting to oci image format                                                                                                                                             0.0s
------
 > exporting to oci image format:
------
Error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists
```

From what I remember, the Docker runtime never did implement OCI manifests fully, so I'm not too surprised by the above.  I need to set up a multi-arch containerd based cluster and see if this is ~close to working.  It might make sense to only support native multi-arch with a containerd based cluster.