### PR TITLE
Add hint for Docker Hub registry name

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ kubectl create secret docker-registry mysecret --docker-server='<registry hostna
 kubectl build --push --registry-secret mysecret -t <registry hostname>/<namespace>/<repo>:<tag> -f Dockerfile ./
 ```
 
+Hint: if you're trying to authenticate to Docker Hub, use `https://index.docker.io/v1/` as the `--docker-server`
+
 ### Registry-based Caching
 
 BuildKit is smart about caching prior build results for efficient incremental


### PR DESCRIPTION
Docker hub uses aliases, so provide a hint for folks
who want to push or pull private images.

I had forgotten the mapping, and had to resort to `... --push --progress=plain` to get a good warning message to remind me.
Lets save others the pain of figuring this out on their own.