### PR TITLE
Add Choco packaging for windows

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -125,11 +125,14 @@ jobs:
       with:
         name: darwin.tgz
         path: bin/darwin.tgz
+        retention-days: 1
     - uses: actions/upload-artifact@v2
       with:
         name: linux.tgz
         path: bin/linux.tgz
+        retention-days: 1
     - uses: actions/upload-artifact@v2
       with:
         name: windows.tgz
         path: bin/windows.tgz
+        retention-days: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    outputs:
+      VERSION: ${{ steps.get_version.outputs.VERSION }}
+      RAW_VERSION: ${{ steps.get_version.outputs.RAW_VERSION }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
     - name: Get the target release version
       id: get_version
@@ -118,12 +122,40 @@ jobs:
         asset_name: darwin-${{ steps.get_version.outputs.VERSION }}.tgz
         asset_content_type: application/tar+gzip
 
-    - name: Upload windows tgz
+    - name: Stage windows binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows.tgz
+        path: bin/windows.tgz
+        retention-days: 1
+
+  winpkg:
+    runs-on: windows-latest
+    needs: "build"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Retrieve built windows.tgz
+      uses: actions/download-artifact@v2
+      with:
+        name: windows.tgz
+        path: packaging/windows/tools/
+    - name: Prep for packaging
+      run: |
+        mkdir packaging/windows/legal
+        cp LICENSE packaging/windows/legal/LICENSE.txt
+        mv packaging/windows/tools/windows.tgz packaging/windows/tools/kubectl-buildkit-${{ steps.get_version.outputs.RAW_VERSION }}.tar.gz
+    - name: Choco Package
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: pack --version ${{ needs.build.outputs.RAW_VERSION }} packaging/windows/kubectl-buildkit.nuspec
+
+    - name: Upload windows Package
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./bin/windows.tgz
-        asset_name: windows-${{ steps.get_version.outputs.VERSION }}.tgz
-        asset_content_type: application/tar+gzip
+        upload_url: ${{ needs.build.outputs.upload_url }}
+        asset_path: kubectl-buildkit.${{ needs.build.outputs.RAW_VERSION }}.nupkg
+        asset_name: kubectl-buildkit.${{ needs.build.outputs.RAW_VERSION }}.nupkg
+        asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ documentation for more information.
 
 ## Getting started
 
+### Installing on Windows
+
+We produce [Choco](https://docs.chocolatey.org/) compatible packages in our https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases
+Just download the latest `nupkg` artifact and in a PowerShell Admin terminal, run
+```
+choco install .\kubectl-buildkit*.nupkg
+```
+
+Note: if you haven't already done so, you will need to run `choco install kubernetes-cli` once to get `kubectl` installed.
+### Installing on Linux
+
+We also produce `.deb` and `.rpm` packages which should work for most distros in our https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases
+Just download the latest artifact and use `yum install ./kubectl-buildkit*.rpm` or `apt install ./kubectl-buildkit*.deb`
+
 ### Installing the tarball
 
 Head over to https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases and download the `tgz` asset for your platform.

--- a/packaging/windows/kubectl-buildkit.nuspec
+++ b/packaging/windows/kubectl-buildkit.nuspec
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>kubectl-buildkit</id>
+    <version>$version$</version>
+    <packageSourceUrl>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl</packageSourceUrl>
+    <owners>BuildKit CLI for kubectl maintainers</owners>
+    <title>BuildKit CLI for kubectl</title>
+    <authors>BuildKit CLI for kubectl maintainers</authors>
+    <projectUrl>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl</projectUrl>
+    <copyright>(c) 2021 VMware Inc.</copyright>
+    <licenseUrl>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl</projectSourceUrl>
+    <docsUrl>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl</docsUrl>
+    <bugTrackerUrl>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/issues</bugTrackerUrl>
+    <tags>kubernetes kubectl buildkit containers devops cli foss</tags>
+    <summary>BuildKit CLI for kubectl is a tool for building container images with your Kubernetes cluster</summary>
+    <description><![CDATA[## BuildKit CLI for kubectl
+
+BuildKit CLI for kubectl is a tool for building OCI and Docker images with your kubernetes cluster.
+It replaces the `docker build` command to let you quickly and easily build your single and
+multi-architecture container images.
+
+## Features
+
+### Drop in replacement for `docker build`
+
+The BuildKit CLI for kubectl replaces the `docker build` command with `kubectl build` to build
+images in your kubernetes cluster, instead of on a single node. Your Dockerfile will be parsed
+the same way as with the existing `docker build` command, and build flags should feel almost
+the same.
+
+### Uses containerd or docker runtime environments
+
+Regardless of whether your Kubernetes cluster is using pure [containerd](https://containerd.io) or
+[docker](https://docker.com), the builder will be able to build OCI compatible images. These
+images can be used inside of your cluster, or pushed to an image registry for distribution.
+]]></description>
+    <releaseNotes>https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/tag/$version$</releaseNotes>
+    <dependencies>
+      <dependency id="kubernetes-cli" version="0.17.7"/>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <file src="legal\**" target="legal" />
+  </files>
+</package>

--- a/packaging/windows/tools/chocolateyInstall.ps1
+++ b/packaging/windows/tools/chocolateyInstall.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName = 'kubectl-buildkit'
+
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+
+$packageArgs = @{
+  PackageName    = $packageName
+  FileFullPath64 = Get-Item $toolsPath\*.tar.gz
+  Destination    = $toolsPath
+}
+Get-ChocolateyUnzip @packageArgs
+
+if (Test-Path "$toolsPath\kubectl-buildkit*.tar") {
+  $packageArgs2 = @{
+    PackageName    = $packageName
+    FileFullPath64 = Get-Item $toolsPath\*.tar
+    Destination    = $toolsPath
+  }
+  Get-ChocolateyUnzip @packageArgs2
+
+  Remove-Item "$toolsPath\kubectl-buildkit*.tar"
+}


### PR DESCRIPTION
Tested via https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/runs/2133977707 by tagging a test release to run the release CI rigging.

I was able to install the resulting nupkg file on a windows 10 VM and run `kubectl buildkit --help` and see results.