### PR TITLE
WIP: Refactor Build routine and add coverage

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Gather integration coverage results
       uses: codecov/codecov-action@v1
       with:
-        file: cover-int.out
+        file: cover-int-containerd.out
         flags: integration-tests
         name: codecov-integration-test-containerd
 
@@ -104,7 +104,7 @@ jobs:
     - name: Gather integration coverage results
       uses: codecov/codecov-action@v1
       with:
-        file: cover-int.out
+        file: cover-int-dockerd.out
         flags: integration-tests
         name: codecov-integration-test-dockerd
 

--- a/integration/common/kubeclient.go
+++ b/integration/common/kubeclient.go
@@ -37,6 +37,7 @@ func RunSimpleBuildImageAsPod(ctx context.Context, name, imageName, namespace st
 	podClient := clientset.CoreV1().Pods(namespace)
 	eventClient := clientset.CoreV1().Events(namespace)
 	logrus.Infof("starting pod %s for image: %s", name, imageName)
+	gracePeriod := int64(0) // Speed up the shutdown at the end
 	// Start the pod
 	pod, err := podClient.Create(ctx,
 		&v1.Pod{
@@ -53,6 +54,7 @@ func RunSimpleBuildImageAsPod(ctx context.Context, name, imageName, namespace st
 						ImagePullPolicy: v1.PullNever,
 					},
 				},
+				TerminationGracePeriodSeconds: &gracePeriod,
 			},
 		},
 		metav1.CreateOptions{},

--- a/integration/suites/localregistry_test.go
+++ b/integration/suites/localregistry_test.go
@@ -399,7 +399,8 @@ func main() {
 		"--builder", s.Name,
 		"--push",
 		"--tag", imageName,
-		"--platform", "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,windows/amd64",
+		//"--platform", "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,windows/amd64",
+		"--platform", "linux/amd64,linux/arm/v7,linux/arm64", // Shorter list...
 		dir,
 	}
 	err = common.RunBuild(args)

--- a/integration/suites/parallel_default_test.go
+++ b/integration/suites/parallel_default_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/integration/common"
@@ -79,7 +80,7 @@ func (s *parallelDefaultSuite) TestParallelDefaultBuilds() {
 	}
 	wg.Wait()
 	for i := 0; i < ParallelDefaultBuildCount; i++ {
-		require.NoError(s.T(), errors[i], "build/run %d failed", i)
+		assert.NoError(s.T(), errors[i], "build/run %d failed", i)
 	}
 }
 

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package build
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/moby/buildkit/client"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_toRepoOnly(t *testing.T) {
+	t.Parallel()
+	_, err := toRepoOnly("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid reference format")
+
+	ret, err := toRepoOnly("short")
+	require.NoError(t, err)
+	require.Equal(t, ret, "docker.io/library/short")
+
+	ret, err = toRepoOnly("short:withtag")
+	require.NoError(t, err)
+	require.Equal(t, ret, "docker.io/library/short")
+
+	ret, err = toRepoOnly("prefix/img:withtag")
+	require.NoError(t, err)
+	require.Equal(t, ret, "docker.io/prefix/img")
+
+	ret, err = toRepoOnly("prefix.with.dots/img:withtag")
+	require.NoError(t, err)
+	require.Equal(t, ret, "prefix.with.dots/img")
+
+}
+
+func Test_LoadInputs(t *testing.T) {
+	solveOpts := &client.SolveOpt{
+		// Minimal initialization set for the routine under test
+		LocalDirs:     map[string]string{},
+		FrontendAttrs: map[string]string{},
+	}
+	f, err := LoadInputs(Inputs{}, solveOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "please specify build context")
+	require.Nil(t, f)
+
+	f, err = LoadInputs(Inputs{
+		ContextPath:    "-",
+		DockerfilePath: "-",
+	}, solveOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "use stdin for both build context and dockerfile")
+	require.Nil(t, f)
+
+	dockerfile := bytes.NewBufferString(`FROM scratch`)
+	f, err = LoadInputs(Inputs{
+		ContextPath:    "-",
+		DockerfilePath: "dummy",
+		InStream:       dockerfile,
+	}, solveOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ambiguous Dockerfile source")
+	require.Nil(t, f)
+
+	f, err = LoadInputs(Inputs{
+		DockerfilePath: "-",
+		InStream:       dockerfile,
+	}, solveOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "please specify build context")
+	require.Nil(t, f)
+
+	f, err = LoadInputs(Inputs{
+		ContextPath:    "https://acme.com/foo",
+		DockerfilePath: "-",
+		InStream:       dockerfile,
+	}, solveOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Dockerfile from stdin is not supported with remote contexts")
+	require.Nil(t, f)
+
+	f, err = LoadInputs(Inputs{
+		ContextPath: "-",
+		InStream:    dockerfile,
+	}, solveOpts)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f()
+
+	f, err = LoadInputs(Inputs{
+		DockerfilePath: "-",
+		ContextPath:    ".",
+		InStream:       dockerfile,
+	}, solveOpts)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f()
+
+	f, err = LoadInputs(Inputs{
+		ContextPath: "https://acme.com/foo",
+	}, solveOpts)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f()
+
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -115,7 +115,7 @@ func Boot(ctx context.Context, d Driver, pw progress.Writer) (*client.Client, st
 				if pw != nil {
 					pw.Status() <- s
 				}
-			}); err != nil && (strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "not found")) {
+			}); err != nil && (strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not match")) {
 				// This most likely means another build is running in parallel
 				// Give it just enough time to finish creating resources then retry
 				time.Sleep(25 * time.Millisecond * time.Duration(1+rand.Int63n(39))) // 25 - 1000 ms

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package driver
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/store"
+)
+
+func Test_GetPlatforms(t *testing.T) {
+	t.Parallel()
+	info := &Info{
+		DynamicNodes: []store.Node{
+			{},
+		},
+	}
+	platforms, mixed := info.GetPlatforms()
+	assert.False(t, mixed)
+	assert.Len(t, platforms, 0)
+
+	armv6 := store.Node{
+		Platforms: []specs.Platform{
+			{
+				Architecture: "arm/v6",
+				OS:           "linux",
+			},
+		},
+	}
+	armv7 := store.Node{
+		Platforms: []specs.Platform{
+			{
+				Architecture: "arm/v7",
+				OS:           "linux",
+			},
+			{
+				Architecture: "arm/v6",
+				OS:           "linux",
+			},
+		},
+	}
+	arm64 := store.Node{
+		Platforms: []specs.Platform{
+			{
+				Architecture: "arm/v7",
+				OS:           "linux",
+			},
+			{
+				Architecture: "arm/v6",
+				OS:           "linux",
+			},
+			{
+				Architecture: "arm64",
+				OS:           "linux",
+			},
+		},
+	}
+	amd64 := store.Node{
+		Platforms: []specs.Platform{
+			{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			{
+				Architecture: "i386",
+				OS:           "linux",
+			},
+		},
+	}
+
+	info = &Info{
+		DynamicNodes: []store.Node{
+			armv6,
+		},
+	}
+	platforms, mixed = info.GetPlatforms()
+	assert.False(t, mixed)
+	assert.Len(t, platforms, 1)
+
+	info = &Info{
+		DynamicNodes: []store.Node{
+			armv6,
+			armv7,
+		},
+	}
+	platforms, mixed = info.GetPlatforms()
+	assert.False(t, mixed)
+	assert.Len(t, platforms, 2)
+
+	info = &Info{
+		DynamicNodes: []store.Node{
+			armv7,
+			armv6,
+		},
+	}
+	platforms, mixed = info.GetPlatforms()
+	assert.False(t, mixed)
+	assert.Len(t, platforms, 2)
+
+	info = &Info{
+		DynamicNodes: []store.Node{
+			armv7,
+			amd64,
+			armv6,
+		},
+	}
+	platforms, mixed = info.GetPlatforms()
+	assert.True(t, mixed)
+	assert.Len(t, platforms, 4)
+
+	info = &Info{
+		DynamicNodes: []store.Node{
+			amd64,
+			arm64,
+		},
+	}
+	platforms, mixed = info.GetPlatforms()
+	assert.True(t, mixed)
+	assert.Len(t, platforms, 5)
+}

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -273,7 +273,10 @@ func (d *Driver) wait(ctx context.Context, sub progress.SubLogger) error {
 
 						sub.Log(1, []byte(fmt.Sprintf("WARN: initial attempt to deploy configured for the %s runtime failed, retrying with %s\n", attemptedRuntime, runtime)))
 						d.InitConfig.DriverOpts["runtime"] = runtime
-						d.InitConfig.DriverOpts["worker"] = "auto"
+						// Leave the users initial intent on worker configuration
+						if d.InitConfig.DriverOpts["worker"] == "" {
+							d.InitConfig.DriverOpts["worker"] = "auto"
+						}
 						err = d.initDriverFromConfig() // This will toggle userSpecifiedRuntime to true to prevent cycles
 						if err != nil {
 							return err

--- a/pkg/platformutil/parse.go
+++ b/pkg/platformutil/parse.go
@@ -34,6 +34,10 @@ func Parse(platformsStr []string) ([]specs.Platform, error) {
 func parse(in string) (specs.Platform, error) {
 	if strings.EqualFold(in, "local") {
 		return platforms.DefaultSpec(), nil
+	} else if strings.EqualFold(in, "auto") {
+		return specs.Platform{
+			Architecture: "auto",
+		}, nil
 	}
 	return platforms.Parse(in)
 }


### PR DESCRIPTION
The primary payload in this PR is a refactoring of the Build routine.

    The multi-driver plumbing in the Build routine was making this routine fragile
    and difficult to adapt to native multi-arch support for the kubernetes driver.
    This doesn't completely remove the Driver abstraction, but should help for
    maintainability.  This does not implement native multi-arch yet (more changes
    will be required)

While working on this refactoring, I added some additional test coverage to build confidence in the refactoring.  Unfortunately while doing so, I uncovered an existing defect, where caching to/from a registry (running in a kube pod) with the containerd runtime causes the Solve call to BuildKit to hang.  I split out this test case and ran it on an unmodified version of the Build routine to confirm I didn't introduce a regression.  For now I've opted to keep that test routine conditional, but we'll want to revisit that and understand the nature of the defect (I think it's likely a bug in BuildKit upstream, but not positive)

While trying to root-cause this hang, I also noticed another defect, where if you do `kubectl buildkit create --worker runc` on a containerd based system, that worker input was getting clobbered and set back to auto, which is now fixed.