### PR TITLE
Add more test coverage for pkg/build

### DIFF
--- a/pkg/build/cache_test.go
+++ b/pkg/build/cache_test.go
@@ -5,15 +5,22 @@ package build
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_isRefOnlyFormat(t *testing.T) {
 	t.Parallel()
 	resp := isRefOnlyFormat([]string{})
-	require.True(t, resp)
+	assert.True(t, resp)
 	resp = isRefOnlyFormat([]string{"foo"})
-	require.True(t, resp)
+	assert.True(t, resp)
 	resp = isRefOnlyFormat([]string{"foo=bar"})
-	require.False(t, resp)
+	assert.False(t, resp)
+}
+
+func Test_ParseCacheEntry(t *testing.T) {
+	t.Parallel()
+	resp, err := ParseCacheEntry([]string{"foo"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
 }

--- a/pkg/build/entitlements_test.go
+++ b/pkg/build/entitlements_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseEntitlements(t *testing.T) {
+	t.Parallel()
+	resp, err := ParseEntitlements([]string{})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 0)
+
+	resp, err = ParseEntitlements([]string{"garbage"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = ParseEntitlements([]string{"security.insecure", "network.host"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 2)
+}

--- a/pkg/build/output.go
+++ b/pkg/build/output.go
@@ -14,8 +14,6 @@ import (
 )
 
 func ParseOutputs(inp []string) ([]client.ExportEntry, error) {
-	//  TODO - experiment with this and see what else needs to be wired up for outputs to work
-
 	var outs []client.ExportEntry
 	if len(inp) == 0 {
 		return nil, nil

--- a/pkg/build/output_test.go
+++ b/pkg/build/output_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseOutputs(t *testing.T) {
+	t.Parallel()
+	resp, err := ParseOutputs([]string{})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 0)
+
+	resp, err = ParseOutputs([]string{"-"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+
+	resp, err = ParseOutputs([]string{"somepath"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+
+	resp, err = ParseOutputs([]string{"type=local,dest=out"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+
+	filename := "/tmp/bktestout.tar"
+	resp, err = ParseOutputs([]string{"type=tar,dest=" + filename})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+	defer func() {
+		os.Remove(filename)
+	}()
+
+	resp, err = ParseOutputs([]string{"type=local"})
+	assert.Error(t, err)
+	assert.Len(t, resp, 0)
+
+	resp, err = ParseOutputs([]string{"type=oci,dest=."})
+	assert.Error(t, err)
+	assert.Len(t, resp, 0)
+
+	resp, err = ParseOutputs([]string{"type=registry"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+
+	resp, err = ParseOutputs([]string{"type=docker"})
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+
+	resp, err = ParseOutputs([]string{"bad=string,extra=foo"})
+	assert.Error(t, err)
+	assert.Len(t, resp, 0)
+}

--- a/pkg/build/secrets_test.go
+++ b/pkg/build/secrets_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseSecretSpecs(t *testing.T) {
+	t.Parallel()
+	resp, err := ParseSecretSpecs([]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	resp, err = ParseSecretSpecs([]string{"type=bogus"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported secret type")
+	assert.Nil(t, resp)
+	resp, err = ParseSecretSpecs([]string{"bogus=bogus"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected key")
+	assert.Nil(t, resp)
+	resp, err = ParseSecretSpecs([]string{"id=mysecret,src=/local/secret/path/doesnt/exist"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+	assert.Nil(t, resp)
+}

--- a/pkg/build/ssh_test.go
+++ b/pkg/build/ssh_test.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseSSHSpecs(t *testing.T) {
+	t.Parallel()
+	resp, err := ParseSSHSpecs([]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	resp, err = ParseSSHSpecs([]string{"someid=bogus-file-does-not-exist"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+	assert.Nil(t, resp)
+}

--- a/pkg/build/utils_test.go
+++ b/pkg/build/utils_test.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_toBuildkitExtraHosts(t *testing.T) {
+	t.Parallel()
+	resp, err := toBuildkitExtraHosts([]string{"foo:127.0.0.1", "bar:8.8.8.8"})
+	assert.NoError(t, err)
+	assert.Equal(t, resp, "foo=127.0.0.1,bar=8.8.8.8")
+
+	resp, err = toBuildkitExtraHosts([]string{"foo:1234"})
+	assert.Error(t, err)
+	assert.Equal(t, resp, "")
+}

--- a/pkg/driver/kubernetes/authprovider_test.go
+++ b/pkg/driver/kubernetes/authprovider_test.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_decodeAuth(t *testing.T) {
+	t.Parallel()
+	username, password, err := decodeAuth("")
+	assert.NoError(t, err)
+	assert.Equal(t, username, "")
+	assert.Equal(t, password, "")
+
+	username, password, err = decodeAuth("badstring")
+	assert.Error(t, err)
+	assert.Equal(t, username, "")
+	assert.Equal(t, password, "")
+
+	// echo -n "jdoe:supersecret" | base64 -i -
+	username, password, err = decodeAuth("amRvZTpzdXBlcnNlY3JldA==")
+	assert.NoError(t, err)
+	assert.Equal(t, username, "jdoe")
+	assert.Equal(t, password, "supersecret")
+
+	// echo -n "baddata" | base64 -i -
+	username, password, err = decodeAuth("YmFkZGF0YQ==")
+	assert.Error(t, err)
+	assert.Equal(t, username, "")
+	assert.Equal(t, password, "")
+}


### PR DESCRIPTION
Closes #18 

When coupled with #77 we should be in pretty good shape on the pkg/build coverage.  ~~Further coverage will come as we flesh out the native multi-arch support.~~ **(multi-arch coverage added to #77)**