### PR TITLE
Refactor BuildKit Image definition

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver"
-	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver/bkimage"
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver/kubernetes"
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/progress"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/version"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -130,7 +130,7 @@ Driver Specific Usage:
 	flags.StringVar(&options.configFile, "config", "", "BuildKit config file")
 	flags.StringArrayVar(&options.platform, "platform", []string{}, "Fixed platforms for current node")
 	flags.StringVar(&options.progress, "progress", "auto", "Set type of progress output [auto, plain, tty]. Use plain to show container output")
-	flags.StringVar(&options.image, "image", "", fmt.Sprintf("Specify an alternate buildkit image (default: %s)", bkimage.DefaultImage))
+	flags.StringVar(&options.image, "image", "", fmt.Sprintf("Specify an alternate buildkit image (default: %s)", version.DefaultImage))
 	flags.StringVar(&options.runtime, "runtime", "auto", "Container runtime used by cluster [auto, docker, containerd]")
 	flags.StringVar(&options.containerdSock, "containerd-sock", kubernetes.DefaultContainerdSockPath, "Path to the containerd.sock on the host")
 	flags.StringVar(&options.containerdNamespace, "containerd-namespace", kubernetes.DefaultContainerdNamespace, "Containerd namespace to build images in")

--- a/pkg/driver/bkimage/bkimage.go
+++ b/pkg/driver/bkimage/bkimage.go
@@ -1,6 +1,0 @@
-package bkimage
-
-const (
-	DefaultImage         = "moby/buildkit:buildx-stable-1" // TODO: make this verified
-	DefaultRootlessImage = "moby/buildkit:v0.6.2-rootless"
-)

--- a/pkg/driver/kubernetes/factory.go
+++ b/pkg/driver/kubernetes/factory.go
@@ -11,9 +11,9 @@ import (
 	"text/template"
 
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver"
-	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver/bkimage"
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver/kubernetes/manifest"
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver/kubernetes/podchooser"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/version"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
@@ -110,7 +110,7 @@ func (d *Driver) initDriverFromConfig() error {
 
 	deploymentOpt := &manifest.DeploymentOpt{
 		Name:                   deploymentName,
-		Image:                  bkimage.DefaultImage,
+		Image:                  version.DefaultImage,
 		Replicas:               1,
 		BuildkitFlags:          cfg.BuildkitFlags,
 		Rootless:               false,
@@ -139,7 +139,7 @@ func (d *Driver) initDriverFromConfig() error {
 				return err
 			}
 			if deploymentOpt.Rootless {
-				deploymentOpt.Image = bkimage.DefaultRootlessImage
+				deploymentOpt.Image = version.DefaultRootlessImage
 			}
 		case "loadbalance":
 			switch v {

--- a/version/version.go
+++ b/version/version.go
@@ -8,6 +8,12 @@ var (
 
 	// Version holds the complete version number. Filled in at linking time.
 	Version = "v0.0.0+unknown"
+
+	// DefaultImage hols the primary build image we use
+	DefaultImage = "docker.io/moby/buildkit:buildx-stable-1"
+
+	// DefaultRootlessImage holds the rootless default image
+	DefaultRootlessImage = "docker.io/moby/buildkit:buildx-stable-1-rootless"
 )
 
 func GetVersionString() string {


### PR DESCRIPTION
Instead of having the image buried in the repo, lets move it up to the
version package to make it easier to find and update.  We may elect
to wrap the image to inject additional helpers in the future.

This also fixes the rootless image to use the latest stable upstream image