### PR TITLE
Give CodeCov more history

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,6 +19,8 @@ jobs:
         go-version: ^${{ env.GO_VERSION }}
     - uses: actions/checkout@v2
       name: Check out code into the Go module directory
+      with:
+        fetch-depth: 0
     - name: Unit Tests
       run: make test
     - name: Codecov
@@ -37,6 +39,8 @@ jobs:
         go-version: ^${{ env.GO_VERSION }}
     - uses: actions/checkout@v2
       name: Check out code into the Go module directory
+      with:
+        fetch-depth: 0
     - name: Setup containerd cluster
       run: |
         set -x
@@ -72,6 +76,8 @@ jobs:
         go-version: ^${{ env.GO_VERSION }}
     - uses: actions/checkout@v2
       name: Check out code into the Go module directory
+      with:
+        fetch-depth: 0
     - name: Setup kubeadm cluster with default docker runtime
       run: |
         set -x


### PR DESCRIPTION
According to some support chatter on CodeCov, having some git history
can help in some cases.

According to https://github.com/codecov/codecov-action/issues/190#issuecomment-753547785 this might help fix some of the CodeCov problems we've been seeing recently...