### PR TITLE
Add MacOS packaging (brew)

### DIFF
--- a/HomebrewFormula/kubectl-buildkit.rb
+++ b/HomebrewFormula/kubectl-buildkit.rb
@@ -1,0 +1,24 @@
+class KubectlBuildkit < Formula
+  desc "BuildKit CLI for kubectl"
+  homepage "https://github.com/vmware-tanzu/buildkit-cli-for-kubectl"
+  url "https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/archive/refs/tags/v0.1.2.tar.gz"
+  license "Apache-2.0"
+  head "https://github.com/kubernetes/kubernetes.git"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    system "make", "build", "VERSION=" + version
+    bin.install Dir["bin/darwin/kubectl-build*"]
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kubectl-buildkit 2>&1")
+    assert_match "BuildKit is a toolkit for converting source code", run_output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ documentation for more information.
 
 ## Getting started
 
+### Installing on MacOS
+
+We include a [Brew](https://docs.brew.sh/) Tap in this repo.  First add the Tap with
+```sh
+brew tap vmware-tanzu/buildkit-cli-for-kubectl https://github.com/vmware-tanzu/buildkit-cli-for-kubectl
+```
+
+Then you can install with
+```sh
+brew install kubectl-buildkit
+```
+
+Keep up-to-date with  `brew upgrade kubectl-buildkit` (or `brew upgrade` to upgrade everything)
+
 ### Installing on Windows
 
 We produce [Choco](https://docs.chocolatey.org/) compatible packages in our https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,6 +18,7 @@ git log --oneline --no-merges --no-decorate v0.1.1..v0.1.2
 * Rephrase commit messages where necessary to better summarize the fix for readability
 * Have another maintainer review the release
 * Publish the release
+* Update the `HomebrewFormula/kubectl-buildkit.rb` to pin to the new version
 
 
 ## When you're making release CI changes


### PR DESCRIPTION
This should make it easier for folks to install the CLI on MacOS.

A few notes:
* I'm not happy with the fact that versions have to be pinned, and there doesn't seem to be a way to make the version driven by `livecheck` and semver calculations.   (something to keep exploring...)
* The notes in the README are untested, so they may require some refinement once this is merged.  I tested it locally and it seemed to work.