### PR TITLE
Enhance version command

### DIFF
--- a/integration/common/basesuites.go
+++ b/integration/common/basesuites.go
@@ -36,7 +36,7 @@ func (s *BaseSuite) SetupSuite() {
 			},
 			s.CreateFlags...,
 		)
-		err := RunBuildkit("create", args)
+		err := RunBuildkit("create", args, RunBuildStreams{})
 		require.NoError(s.T(), err, "%s: builder create failed", s.Name)
 	}
 
@@ -49,7 +49,7 @@ func (s *BaseSuite) TearDownSuite() {
 	logrus.Infof("%s: Removing builder", s.Name)
 	err := RunBuildkit("rm", []string{
 		s.Name,
-	})
+	}, RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder rm failed", s.Name)
 	configMapClient := s.ClientSet.CoreV1().ConfigMaps(s.Namespace)
 	_, err = configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
@@ -76,7 +76,7 @@ func (s *BaseSuite) TestSimpleBuild() {
 		"--tag", imageName,
 		dir,
 	)
-	err = RunBuild(args)
+	err = RunBuild(args, RunBuildStreams{})
 	if isRootlessCreate(s.CreateFlags) {
 		require.Error(s.T(), err)
 		require.Contains(s.T(), err.Error(), "please specify")
@@ -116,7 +116,7 @@ func (s *BaseSuite) TestLocalOutputTarBuild() {
 		fmt.Sprintf("--output=type=tar,dest=%s", path.Join(dir, "out.tar")),
 		dir,
 	)
-	err = RunBuild(args)
+	err = RunBuild(args, RunBuildStreams{})
 	require.NoError(s.T(), err, "build failed")
 	// TODO - consider inspecting the out.tar for validity...
 }

--- a/integration/common/basesuites.go
+++ b/integration/common/basesuites.go
@@ -3,6 +3,7 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"path"
@@ -119,4 +120,16 @@ func (s *BaseSuite) TestLocalOutputTarBuild() {
 	err = RunBuild(args, RunBuildStreams{})
 	require.NoError(s.T(), err, "build failed")
 	// TODO - consider inspecting the out.tar for validity...
+}
+
+func (s *BaseSuite) TestLs() {
+	buf := &bytes.Buffer{}
+	err := RunBuildkit("ls", []string{}, RunBuildStreams{Out: buf})
+	require.NoError(s.T(), err, "%s: ls failed", s.Name)
+	lines := buf.String()
+	require.Contains(s.T(), lines, s.Name)
+
+	err = RunBuildkit("ls", []string{"dummy"}, RunBuildStreams{})
+	require.Error(s.T(), err)
+	require.Contains(s.T(), err.Error(), "requires exactly")
 }

--- a/integration/common/runners.go
+++ b/integration/common/runners.go
@@ -3,6 +3,7 @@
 package common
 
 import (
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -15,23 +16,40 @@ import (
 	_ "github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver/kubernetes"
 )
 
-func RunBuild(args []string) error {
+// RunBuildStreams can override in/out/err streams if the output needs to be evaluated
+// if unset, stdin/stdout/stderr will be used
+type RunBuildStreams struct {
+	In  io.Reader
+	Out io.Writer
+	Err io.Writer
+}
+
+func RunBuild(args []string, streams RunBuildStreams) error {
 	flags := pflag.NewFlagSet("kubectl-build", pflag.ExitOnError)
 	pflag.CommandLine = flags
 	finalArgs := append(
 		[]string{"--kubeconfig", os.Getenv("TEST_KUBECONFIG")},
 		args...,
 	)
+	if streams.In == nil {
+		streams.In = os.Stdin
+	}
+	if streams.Out == nil {
+		streams.Out = os.Stdout
+	}
+	if streams.Err == nil {
+		streams.Err = os.Stderr
+	}
 
 	// TODO do we want to capture the output someplace else?
-	root := commands.NewRootBuildCmd(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root := commands.NewRootBuildCmd(genericclioptions.IOStreams{In: streams.In, Out: streams.Out, ErrOut: streams.Err})
 	root.SetArgs(finalArgs)
 	logrus.Infof("Build: %v", finalArgs)
 
 	return root.Execute()
 }
 
-func RunBuildkit(command string, args []string) error {
+func RunBuildkit(command string, args []string, streams RunBuildStreams) error {
 	flags := pflag.NewFlagSet("kubectl-buildkit", pflag.ExitOnError)
 	pflag.CommandLine = flags
 	finalArgs := append(
@@ -39,8 +57,17 @@ func RunBuildkit(command string, args []string) error {
 		args...,
 	)
 	logrus.Infof("CMD: %v", finalArgs)
+	if streams.In == nil {
+		streams.In = os.Stdin
+	}
+	if streams.Out == nil {
+		streams.Out = os.Stdout
+	}
+	if streams.Err == nil {
+		streams.Err = os.Stderr
+	}
 
-	root := commands.NewRootCmd(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root := commands.NewRootCmd(genericclioptions.IOStreams{In: streams.In, Out: streams.Out, ErrOut: streams.Err})
 	root.SetArgs(finalArgs)
 
 	return root.Execute()

--- a/integration/suites/configmap_test.go
+++ b/integration/suites/configmap_test.go
@@ -64,7 +64,7 @@ func (s *configMapSuite) TestDefaultCreate() {
 		},
 		s.CreateFlags...,
 	)
-	err := common.RunBuildkit("create", args)
+	err := common.RunBuildkit("create", args, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder create failed", s.Name)
 	cfg, err := s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.NoError(s.T(), err, "%s: fetch configmap failed", s.Name)
@@ -78,7 +78,7 @@ func (s *configMapSuite) TestDefaultCreate() {
 	logrus.Infof("%s: Removing builder", s.Name)
 	err = common.RunBuildkit("rm", []string{
 		s.Name,
-	})
+	}, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder rm failed", s.Name)
 	_, err = s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.Error(s.T(), err, "config map wasn't cleaned up")
@@ -98,7 +98,7 @@ func (s *configMapSuite) TestPreExistingConfigDefaultCreate() {
 		},
 		s.CreateFlags...,
 	)
-	err = common.RunBuildkit("create", args)
+	err = common.RunBuildkit("create", args, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder create failed", s.Name)
 	cfg, err := s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.NoError(s.T(), err, "%s: fetch configmap failed", s.Name)
@@ -112,7 +112,7 @@ func (s *configMapSuite) TestPreExistingConfigDefaultCreate() {
 	logrus.Infof("%s: Removing builder", s.Name)
 	err = common.RunBuildkit("rm", []string{
 		s.Name,
-	})
+	}, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder rm failed", s.Name)
 	_, err = s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	// TODO if we preserve pre-existing configmaps this will need to be refined.
@@ -137,7 +137,7 @@ func (s *configMapSuite) TestCustomCreate() {
 		},
 		s.CreateFlags...,
 	)
-	err = common.RunBuildkit("create", args)
+	err = common.RunBuildkit("create", args, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder create failed", s.Name)
 	cfg, err := s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.NoError(s.T(), err, "%s: fetch configmap failed", s.Name)
@@ -152,7 +152,7 @@ func (s *configMapSuite) TestCustomCreate() {
 	logrus.Infof("%s: Removing builder", s.Name)
 	err = common.RunBuildkit("rm", []string{
 		s.Name,
-	})
+	}, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder rm failed", s.Name)
 	_, err = s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.Error(s.T(), err, "config map wasn't cleaned up")
@@ -179,7 +179,7 @@ func (s *configMapSuite) TestPreExistingWithCustomCreate() {
 		},
 		s.CreateFlags...,
 	)
-	err = common.RunBuildkit("create", args)
+	err = common.RunBuildkit("create", args, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder create failed", s.Name)
 	cfg, err := s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.NoError(s.T(), err, "%s: fetch configmap failed", s.Name)
@@ -195,7 +195,7 @@ func (s *configMapSuite) TestPreExistingWithCustomCreate() {
 	logrus.Infof("%s: Removing builder", s.Name)
 	err = common.RunBuildkit("rm", []string{
 		s.Name,
-	})
+	}, common.RunBuildStreams{})
 	require.NoError(s.T(), err, "%s: builder rm failed", s.Name)
 	_, err = s.configMapClient.Get(context.Background(), s.Name, metav1.GetOptions{})
 	require.Error(s.T(), err, "config map wasn't cleaned up")

--- a/integration/suites/default_test.go
+++ b/integration/suites/default_test.go
@@ -3,14 +3,27 @@
 package suites
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/integration/common"
 )
 
 type DefaultSuite struct{ common.BaseSuite }
+
+func (s *DefaultSuite) TestVersion() {
+	buf := &bytes.Buffer{}
+	err := common.RunBuildkit("version", []string{}, common.RunBuildStreams{Out: buf})
+	require.NoError(s.T(), err, "%s: builder version failed", s.Name)
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(s.T(), lines, 2)
+	require.Contains(s.T(), lines[0], "Client:")
+	require.Contains(s.T(), lines[1], "buildkitd")
+}
 
 func TestDefaultSuite(t *testing.T) {
 	common.Skipper(t)

--- a/integration/suites/parallel_default_test.go
+++ b/integration/suites/parallel_default_test.go
@@ -62,7 +62,7 @@ func (s *parallelDefaultSuite) TestParallelDefaultBuilds() {
 				"--tag", imageName,
 				dirs[i],
 			}
-			err := common.RunBuild(args)
+			err := common.RunBuild(args, common.RunBuildStreams{})
 			if err != nil {
 				errors[i] = err
 				return

--- a/integration/suites/rootless_test.go
+++ b/integration/suites/rootless_test.go
@@ -34,7 +34,7 @@ func (s *rootlessSuite) TestBuildWithoutPush() {
 		"--tag", imageName,
 		dir,
 	}
-	err = common.RunBuild(args)
+	err = common.RunBuild(args, common.RunBuildStreams{})
 	require.Error(s.T(), err)
 	require.Contains(s.T(), err.Error(), "please specify --push")
 }

--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -4,7 +4,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -35,7 +34,7 @@ func runLs(streams genericclioptions.IOStreams, in lsOptions) error {
 		builders = append(builders, b...)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(streams.Out, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "NAME\tNODE\tDRIVER\tSTATUS\tPLATFORMS\n")
 
 	for _, b := range builders {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -52,7 +52,7 @@ func addCommands(cmd *cobra.Command, streams genericclioptions.IOStreams) {
 		//stopCmd(streams, opts),
 		//installCmd(streams),
 		//uninstallCmd(streams),
-		versionCmd(streams),
+		versionCmd(streams, opts),
 		//pruneCmd(streams, opts),
 		//duCmd(streams, opts),
 		//imagetoolscmd.RootCmd(streams),

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -3,24 +3,68 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/moby/buildkit/util/appcontext"
 	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/pkg/driver"
 	"github.com/vmware-tanzu/buildkit-cli-for-kubectl/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func runVersion(streams genericclioptions.IOStreams) error {
-	fmt.Println(version.Version)
+type versionOptions struct {
+	builder string
+	commonKubeOptions
+}
+
+func getBuilderVersion(ctx context.Context, in versionOptions) string {
+	driverName := in.builder
+	if driverName == "" {
+		driverName = "buildkit"
+	}
+	d, err := driver.GetDriver(ctx, driverName, nil, in.KubeClientConfig, []string{}, "" /* unused config file */, map[string]string{} /* DriverOpts unused */, "")
+	if err != nil {
+		return err.Error()
+	}
+	version, err := d.GetVersion(ctx)
+	if err != nil {
+		return err.Error()
+	}
+	return version
+}
+
+func runVersion(streams genericclioptions.IOStreams, in versionOptions) error {
+	ctx := appcontext.Context()
+	builderVersion := getBuilderVersion(ctx, in)
+
+	fmt.Fprintf(streams.Out, "Client:  %s\n", version.Version)
+	fmt.Fprintf(streams.Out, "Builder: %s\n", builderVersion)
 	return nil
 }
 
-func versionCmd(streams genericclioptions.IOStreams) *cobra.Command {
+func versionCmd(streams genericclioptions.IOStreams, rootOpts *rootOptions) *cobra.Command {
+	options := versionOptions{
+		commonKubeOptions: commonKubeOptions{
+			configFlags: genericclioptions.NewConfigFlags(true),
+			IOStreams:   streams,
+		},
+	}
+
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Show version information ",
+		Short: "Show client and builder version information ",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVersion(streams)
+			options.builder = rootOpts.builder
+
+			if err := options.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := options.Validate(); err != nil {
+				return err
+			}
+
+			return runVersion(streams, options)
 		},
 	}
 	return cmd

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -81,6 +81,7 @@ type Driver interface {
 	Features() map[Feature]bool
 	List(ctx context.Context) ([]Builder, error)
 	RuntimeSockProxy(ctx context.Context, name string) (net.Conn, error)
+	GetVersion(ctx context.Context) (string, error)
 
 	// TODO - do we really need both?  Seems like some cleanup needed here...
 	GetAuthWrapper(string) imagetools.Auth

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -298,12 +298,12 @@ func (d *Driver) GetVersion(ctx context.Context) (string, error) {
 			Stderr:    true,
 			TTY:       false,
 		}, scheme.ParameterCodec)
+	req.Timeout(10 * time.Second)
 	u := req.URL()
 	exec, err := remotecommand.NewSPDYExecutor(restClientConfig, "POST", u)
 	if err != nil {
 		return "", err
 	}
-	// TODO how to timeout if something goes bad...?
 	serr := exec.Stream(remotecommand.StreamOptions{
 		Stdout: buf,
 		Stderr: os.Stderr,

--- a/pkg/driver/kubernetes/podchooser/podchooser.go
+++ b/pkg/driver/kubernetes/podchooser/podchooser.go
@@ -57,6 +57,9 @@ func (pc *StickyPodChooser) ChoosePod(ctx context.Context) (*corev1.Pod, []*core
 	if err != nil {
 		return nil, nil, err
 	}
+	if len(pods) == 0 {
+		return nil, nil, fmt.Errorf("no builder pods are running")
+	}
 	var podNames []string
 	podMap := make(map[string]*corev1.Pod, len(pods))
 	for _, pod := range pods {
@@ -89,9 +92,13 @@ func (pc *StickyPodChooser) ChoosePod(ctx context.Context) (*corev1.Pod, []*core
 }
 
 func ListRunningPods(ctx context.Context, client clientcorev1.PodInterface, depl *appsv1.Deployment) ([]*corev1.Pod, error) {
+	name := depl.ObjectMeta.Name
+	if name == "" {
+		name = "buildkit" // TODO should be constant someplace...
+	}
 	labelSelector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"app": depl.ObjectMeta.Name,
+			"app": name,
 		},
 	}
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)


### PR DESCRIPTION
This improves the version command to report both client and builder
version information.

Closes #88 

Without builder running:
```
Client:  v0.1.3-1-g2372be6-dirty
Builder: no builder pods are running
```

With builder running:
```
Client:  v0.1.3-1-g2372be6-dirty
Builder: buildkitd github.com/moby/buildkit v0.7.2 22e230744171b4442101731951bbbecf97796ea5
```