### PR TITLE
Unmask error in retry loop and add time

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test-unit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go ${{ env.GO_VERSION }}
       uses: actions/setup-go@v2
@@ -31,7 +31,7 @@ jobs:
         name: codecov-unit-test
 
   test-integration-containerd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go ${{ env.GO_VERSION }}
       uses: actions/setup-go@v2
@@ -44,7 +44,10 @@ jobs:
     - name: Setup containerd cluster
       run: |
         set -x
-        sudo apt-get install -y kubeadm kubelet
+        sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+        sudo apt-get update
+        sudo apt-get install -y kubelet kubeadm kubectl
         sudo swapoff -a
         # Ensure dockerd isn't running
         sudo systemctl stop docker.socket
@@ -68,7 +71,7 @@ jobs:
         name: codecov-integration-test-containerd
 
   test-integration-dockerd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go ${{ env.GO_VERSION }}
       uses: actions/setup-go@v2
@@ -81,7 +84,10 @@ jobs:
     - name: Setup kubeadm cluster with default docker runtime
       run: |
         set -x
-        sudo apt-get install -y kubeadm kubelet
+        sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+        sudo apt-get update
+        sudo apt-get install -y kubelet kubeadm kubectl
         sudo swapoff -a
         sudo kubeadm init
         mkdir -p $HOME/.kube/
@@ -103,7 +109,7 @@ jobs:
         name: codecov-integration-test-dockerd
 
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go ${{ env.GO_VERSION }}
       uses: actions/setup-go@v2
@@ -117,7 +123,7 @@ jobs:
         version: v1.29
 
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go ${{ env.GO_VERSION }}
       uses: actions/setup-go@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.get_version.outputs.VERSION }}
       RAW_VERSION: ${{ steps.get_version.outputs.RAW_VERSION }}


### PR DESCRIPTION
Containerd integration tests are a little flaky.  Let's see if this helps.

Recent merge to main CI seems to be failing.  Notable log output:

```
2021-04-02T20:36:10.1995307Z     parallel_default_test.go:82: 
2021-04-02T20:36:10.1995885Z         	Error Trace:	parallel_default_test.go:82
2021-04-02T20:36:10.1996515Z         	Error:      	Received unexpected error:
2021-04-02T20:36:10.1997190Z         	            	failed to bootstrap builder in 4 attempts (%!s(<nil>))
...
2021-04-02T20:36:10.2019489Z --- FAIL: TestParallelDefaultBuildSuite (11.90s)
2021-04-02T20:36:10.2020914Z     --- FAIL: TestParallelDefaultBuildSuite/TestParallelDefaultBuilds (11.90s)
```

I overlooked the `:=` in my prior refinement on this logging message so the actual error message is getting masked.  This should unmask it so we can see the actual error message from the last attempt.

I've also added a small back-off to the sleep in the retry which might help.