### PR TITLE
feat: Allow to add environment variable on builder instance

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -245,7 +245,7 @@ func buildTargets(ctx context.Context, kubeClientConfig clientcmd.ClientConfig, 
 		"HTTPS_PROXY",
 		"NO_PROXY",
 	}
-	envs := make([]string, 0, 0)
+	envs := make([]string, 0)
 	for _, env := range listEnvToCheck {
 		val, isSet := os.LookupEnv(env)
 		if isSet {

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -42,6 +42,7 @@ type createOptions struct {
 	configFile          string
 	progress            string
 	customConfig        string
+	envs                []string
 }
 
 func runCreate(streams genericclioptions.IOStreams, in createOptions, rootOpts *rootOptions) error {
@@ -78,6 +79,7 @@ func runCreate(streams genericclioptions.IOStreams, in createOptions, rootOpts *
 		"docker-sock":          in.dockerSock,
 		"runtime":              in.runtime,
 		"custom-config":        in.customConfig,
+		"env":                  strings.Join(in.envs, ";"),
 	}
 
 	d, err := driver.GetDriver(ctx, in.name, driverFactory, rootOpts.KubeClientConfig, flags, in.configFile, driverOpts, "" /*contextPathHash*/)
@@ -140,6 +142,7 @@ Driver Specific Usage:
 	flags.StringVar(&options.loadbalance, "loadbalance", "random", "Load balancing strategy [random, sticky]")
 	flags.StringVar(&options.worker, "worker", "auto", "Worker backend [auto, runc, containerd]")
 	flags.StringVar(&options.customConfig, "custom-config", "", "Name of a ConfigMap containing custom files (e.g., certs), mounted in /etc/config/ - use 'kubectl create configmap ... --from-file=...'")
+	flags.StringArrayVar(&options.envs, "env", []string{}, "Environment variable to add when create builder, like http_proxy=http://my-proxy.com:8080")
 
 	return cmd
 }

--- a/pkg/driver/kubernetes/factory.go
+++ b/pkg/driver/kubernetes/factory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -183,11 +182,10 @@ func (d *Driver) initDriverFromConfig() error {
 			deploymentOpt.CustomConfig = v
 		case "env":
 			// Split over comma for multiple key/value
-			re := regexp.MustCompile(`([^=]+)=([^=]+)`)
 			for _, item := range strings.Split(v, ";") {
-				m := re.FindStringSubmatch(strings.TrimSpace(item))
-				if len(m) == 3 {
-					deploymentOpt.Environments[m[1]] = m[2]
+				m := strings.SplitN(item, "=", 2)
+				if len(m) == 2 {
+					deploymentOpt.Environments[m[0]] = m[1]
 				}
 			}
 		default:

--- a/pkg/driver/kubernetes/manifest/manifest.go
+++ b/pkg/driver/kubernetes/manifest/manifest.go
@@ -24,6 +24,7 @@ type DeploymentOpt struct {
 	DockerSockHostPath     string
 	ContainerRuntime       string
 	CustomConfig           string
+	Environments		   map[string]string
 }
 
 const (
@@ -46,9 +47,19 @@ func annotations(opt *DeploymentOpt) map[string]string {
 	}
 }
 
+func environments(opt *DeploymentOpt) []corev1.EnvVar {
+	envs := make([]corev1.EnvVar, 0, len(opt.Environments))
+	for name, value := range opt.Environments {
+		envs = append(envs, corev1.EnvVar{Name: name, Value: value})
+	}	
+
+	return envs
+}
+
 func NewDeployment(opt *DeploymentOpt) (*appsv1.Deployment, error) {
 	labels := labels(opt)
 	annotations := annotations(opt)
+	environments := environments(opt)
 	replicas := int32(opt.Replicas)
 	privileged := true
 	args := opt.BuildkitFlags
@@ -94,6 +105,7 @@ func NewDeployment(opt *DeploymentOpt) (*appsv1.Deployment, error) {
 									MountPath: "/etc/buildkit/",
 								},
 							},
+							Env: environments,
 						},
 					},
 					Volumes: []corev1.Volume{

--- a/pkg/driver/kubernetes/manifest/manifest.go
+++ b/pkg/driver/kubernetes/manifest/manifest.go
@@ -24,7 +24,7 @@ type DeploymentOpt struct {
 	DockerSockHostPath     string
 	ContainerRuntime       string
 	CustomConfig           string
-	Environments		   map[string]string
+	Environments           map[string]string
 }
 
 const (
@@ -51,7 +51,7 @@ func environments(opt *DeploymentOpt) []corev1.EnvVar {
 	envs := make([]corev1.EnvVar, 0, len(opt.Environments))
 	for name, value := range opt.Environments {
 		envs = append(envs, corev1.EnvVar{Name: name, Value: value})
-	}	
+	}
 
 	return envs
 }


### PR DESCRIPTION
Signed-off-by: disaster37 <linuxworkgroup@hotmail.com>

Fix #54.

This PR allow to add environment variable when create new builder instance.
For exemple:
```bash
kubectl builder create --env "http_proxy=http://my-proxy:8080" --env "https_proxy=https://my-proxy:8080"
```

More over, if you run `kubectl build` before create builder, it will check if `http_proxy`, `https_proxy`, `no_proxy`, `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are set on current shell. And then pass them on builder factory...